### PR TITLE
ci: nightly security-scan (leverj/security-scan → Project #8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,31 @@ orbs:
   path-filtering: circleci/path-filtering@3.0.0
   continuation: circleci/continuation@1.0.0
 
+# Set true ONLY by the `nightly-security-scan` scheduled pipeline (created via the
+# CircleCI API — see .dev/ci-security-scan.md). On a normal push it defaults false,
+# so the `setup` workflow runs and `security-scan` is skipped. When the schedule
+# sets it true, `setup` is skipped (no path-filtering / continuation) and
+# `security-scan` runs the leverj/security-scan image against the checkout, filing
+# deduplicated findings into GitHub Project #8.
+parameters:
+  run-security-scan:
+    type: boolean
+    default: false
+
 workflows:
   setup:
+    when:
+      not: << pipeline.parameters.run-security-scan >>
     jobs:
       - filter-and-continue
+
+  security-scan:
+    when: << pipeline.parameters.run-security-scan >>
+    jobs:
+      - security-scan:
+          # Reuses the org-level `ezel-security-scan` context (leverj org). Its
+          # SECURITY_SCAN_TOKEN PAT must also grant lever repo + Project #8.
+          context: [ezel-security-scan]
 
 jobs:
   filter-and-continue:
@@ -71,3 +92,36 @@ jobs:
       - continuation/continue:
           configuration_path: .circleci/continue-config.yml
           parameters: /tmp/pipeline-parameters.json
+
+  # Nightly deterministic security scan (leverj/security-scan Docker image) against
+  # the checked-out tree, filing deduplicated findings into GitHub Project #8. Runs
+  # on the self-hosted mac mini (resource_class leverj/macos); Colima provides the
+  # Docker runtime. `brew shellenv` is required because the runner's task shell is
+  # non-login, so /opt/homebrew/bin (colima, docker) is otherwise off PATH. Secrets
+  # come from the `ezel-security-scan` context — see .dev/ci-security-scan.md.
+  security-scan:
+    machine: true
+    resource_class: leverj/macos
+    steps:
+      - checkout
+      - run:
+          name: Ensure container runtime (Colima) is up
+          command: |
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+            colima status >/dev/null 2>&1 || colima start --cpu 4 --memory 8 --disk 60
+      - run:
+          name: Run leverj/security-scan → Project #8
+          no_output_timeout: 30m
+          command: |
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+            # Fail loud if the config didn't make it into the clone — the scanner
+            # image exits 0 on a missing config, which would otherwise pass silently.
+            test -f .security-scan/config.yaml || { echo "ERROR: .security-scan/config.yaml not in checkout"; exit 1; }
+            docker pull -q leverj/security-scan:latest
+            docker run --rm \
+              -v "${PWD}/.security-scan:/config:ro" \
+              -v "${PWD}:/work" \
+              -e GITHUB_TOKEN="${SECURITY_SCAN_TOKEN}" \
+              -e SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}" \
+              leverj/security-scan:latest \
+              --repo-dir /work

--- a/.dev/ci-security-scan.md
+++ b/.dev/ci-security-scan.md
@@ -1,0 +1,114 @@
+# CI security scan (CircleCI)
+
+Nightly deterministic security scan that runs the `leverj/security-scan` Docker
+image against the checked-out tree and files deduplicated findings into
+**GitHub Project #8** (`leverj/lever-security-issues`). Mirrors the ezel/gallery
+setup, minus the Supabase lane (lever isn't Supabase-backed). Slack run-summaries
+are enabled (`slack.enabled: true`) — they fire only when `SLACK_WEBHOOK_URL` is
+present in the CI context (step 3 below); without it the scanner skips Slack.
+
+LLM SAST (codex + claude) is configured separately in
+`.security-scan/config-llm.yaml`, driven by the host-side `security-scan-llm` CLI
+(`leverj:security-scan-llm` skill), filing into the same Project #8.
+
+## How it's wired
+
+`.circleci/config.yml` (the dynamic-config setup pipeline) defines:
+
+- A `run-security-scan` **pipeline parameter** (default `false`).
+- The `setup` workflow is gated `when: not run-security-scan` — normal pushes do
+  path-filtering / per-package tests and are unaffected.
+- A `security-scan` workflow gated `when: run-security-scan`, with one
+  `security-scan` job on the **self-hosted mac mini** (`resource_class:
+  leverj/macos`). Colima provides the Docker runtime; the job starts it if it
+  isn't already up. It pulls `leverj/security-scan:latest` and runs it with
+  `--repo-dir /work`, the repo's `.security-scan/` bind-mounted at `/config:ro`.
+  This is the same runner ezel/gallery's nightly scans use.
+
+The job reads `SECURITY_SCAN_TOKEN` from the **`ezel-security-scan`** context —
+the same org-level (leverj) context ezel and gallery use. CircleCI contexts are
+shared across an org's projects, so lever reuses it rather than duplicating the
+secret; the PAT just needs lever repo + Project #8 access too. The scanner dedups
+via fingerprints, so nightly runs only file *new* findings.
+
+## Prerequisite: the self-hosted runner
+
+This job targets the `leverj/macos` self-hosted runner (the mac mini). It must be
+registered and online in CircleCI Self-Hosted Runners, with Homebrew + Colima +
+Docker CLI installed under `/opt/homebrew/bin`. Same runner ezel/gallery use; if
+their nightly scans run, lever's will too.
+
+## One-time setup (cannot be done from the repo — do these once)
+
+### 1. Reuse ezel's `ezel-security-scan` context — just widen the PAT
+
+No new context needed. The pipeline references the existing org-level
+`ezel-security-scan` context. Its `SECURITY_SCAN_TOKEN` (a GitHub PAT with
+**`repo` + `project`** scope) must be able to write issues on `leverj/lever` and
+items on **Project #8** in addition to ezel/gallery. If the PAT is fine-grained,
+add `leverj/lever` to its repository access and grant the org Projects
+permission; if it's classic with org-wide `repo` + `project`, it already covers
+lever.
+
+(No CircleCI changes for this step — it's purely a GitHub PAT scope update.)
+
+### 2. Create the nightly scheduled pipeline
+
+CircleCI scheduled pipelines are created via API/UI, not in-config. This one sets
+`run-security-scan: true` on branch `main` once a day (02:00 UTC).
+
+**Key gotcha:** `run-security-scan: true` MUST be in `parameters`. Without it the
+pipeline runs the normal `setup` workflow, not the scan.
+
+```bash
+export CIRCLECI_TOKEN=<token from https://app.circleci.com/settings/user/tokens>
+SLUG=gh/leverj/lever
+
+# create the schedule (daily 02:00 UTC on main; runs as the token owner so it
+# inherits their access to the ezel-security-scan context)
+curl -sS -X POST "https://circleci.com/api/v2/project/$SLUG/schedule" \
+  -H "Circle-Token: $CIRCLECI_TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "nightly-security-scan",
+    "description": "Nightly leverj/security-scan -> Project #8",
+    "attribution-actor": "current",
+    "parameters": { "branch": "main", "run-security-scan": true },
+    "timetable": { "per-hour": 1, "hours-of-day": [2],
+      "days-of-week": ["MON","TUE","WED","THU","FRI","SAT","SUN"] }
+  }'
+
+# verify
+curl -sS -H "Circle-Token: $CIRCLECI_TOKEN" \
+  "https://circleci.com/api/v2/project/$SLUG/schedule" | jq '.items[] | {name,timetable,parameters}'
+```
+
+**Test it now** (one scan run immediately, without waiting for 02:00 UTC):
+
+```bash
+curl -sS -X POST "https://circleci.com/api/v2/project/$SLUG/pipeline" \
+  -H "Circle-Token: $CIRCLECI_TOKEN" -H "Content-Type: application/json" \
+  -d '{ "branch": "main", "parameters": { "run-security-scan": true } }'
+```
+
+The `leverj/macos` runner (mac mini) must be **online** when the pipeline fires,
+or the job queues until it is.
+
+**UI alternative:** Project → *Project Settings → Triggers → Add Trigger →
+Schedule*; set branch `main`, your cadence, and under *Pipeline parameters* add
+`run-security-scan` = `true`. Same result — don't skip the parameter.
+
+### 3. Slack run-summaries (`SLACK_WEBHOOK_URL`)
+
+`config.yaml` has `slack.enabled: true`, and the `security-scan` job forwards
+`-e SLACK_WEBHOOK_URL` into the container. To make summaries post, add a
+`SLACK_WEBHOOK_URL` env var to the **`ezel-security-scan`** context (CircleCI →
+*Organization Settings → Contexts → ezel-security-scan*). It's wired as
+`${SLACK_WEBHOOK_URL:-}`, so until the var exists the job runs fine and just skips
+Slack — no failed builds. (If ezel/gallery already set it on this shared context,
+lever inherits it automatically.)
+
+## Note on first-run volume
+
+The initial backlog can be large. GitHub's secondary rate limit caps content
+creation at ~500 issues/hour, so a big first filing may need two passes an hour
+apart. After that, nightly runs only file deltas and stay well under the limit.

--- a/.security-scan/config-llm.yaml
+++ b/.security-scan/config-llm.yaml
@@ -1,0 +1,56 @@
+# leverj/security-scan-llm — LLM SAST lanes for leverj/lever
+# Consumed by the `leverj:security-scan-llm` skill + the host-side
+# security-scan-llm CLI. Independent from config.yaml (deterministic).
+# Schema v2 (tool v0.3.0). Files into the same Projects v2 board (#8).
+# Mirrors the gallery setup, retargeted to leverj/lever (4.x `main`).
+#
+# Active lanes: codex + claude (both cloud, on subscription), cross-referencing
+# each other. Add an `ollama` lane on a bigger box.
+
+repo: leverj/lever
+ref: main
+
+project:
+  owner: leverj
+  number: 8
+
+github_token_env: GITHUB_TOKEN
+
+severity_floor: low
+
+paths:
+  exclude: []
+
+# Each lane is an LLM that scans the repo; any two lanes cross-reference each
+# other. backend: codex-cli | claude-cli | ollama. name = scanner label / rule
+# prefix (so a lane named `qwen` files findings as `qwen.*`).
+lanes:
+  - name: codex
+    backend: codex-cli
+    model: null              # null => the codex CLI default
+    timeout: 1200
+    validate_timeout: 300
+
+  - name: claude
+    backend: claude-cli
+    model: claude-sonnet-4-6
+    timeout: 1200
+    validate_timeout: 300
+
+  # Enable on a bigger host:
+  # - name: qwen
+  #   backend: ollama
+  #   model: qwen2.5-coder:32b
+  #   base_url: http://localhost:11434   # MUST be loopback or RFC1918
+  #   timeout: 1800
+
+cross_validate:
+  enabled: true              # each finding reviewed by a different lane (needs ≥2 lanes)
+
+triage:
+  enabled: false
+  intro_enabled: true
+  prose_enabled: false
+  fuzzy_dup_enabled: false
+  timeout: 600
+  prewarm: true

--- a/.security-scan/config.yaml
+++ b/.security-scan/config.yaml
@@ -1,0 +1,59 @@
+# leverj/security-scan — DETERMINISTIC lanes for leverj/lever
+# Consumed by the `leverj:security-scan` skill + the Docker image.
+# Schema v4 (image v0.5.1). LLM lanes (codex/claude/gemma) live in config-llm.yaml.
+# Mirrors the gallery setup, retargeted to leverj/lever (4.x `main`) + board #8.
+
+repo: leverj/lever
+ref: main
+
+project:
+  owner: leverj
+  number: 8
+
+github_token_env: GITHUB_TOKEN
+
+secrets:
+  source: env            # GITHUB_TOKEN from `gh auth token`; flip to 1password + env_file if needed
+  env_file: null
+
+slack:
+  enabled: true          # posts a per-run summary; requires SLACK_WEBHOOK_URL in the CI context
+  webhook_url_env: SLACK_WEBHOOK_URL
+
+scanners:
+  osv: true
+  gitleaks: true
+  semgrep: true
+  trivy: true
+  trufflehog: true
+  syft: true
+  supply_chain: false   # Socket.dev lockfile analysis; needs SOCKET_API_KEY (off)
+
+image_scan:
+  base_images: true     # lever ships no Dockerfiles, so this is a no-op; kept for parity
+  built_image:
+    enabled: false
+    ref: null
+    build_locally: false
+  timeout: 600
+
+supabase:
+  enabled: false         # lever isn't Supabase-backed
+  url_env: SUPABASE_DB_URL
+  host_env: null
+  db_env: null
+  user_env: null
+  password_env: null
+  port: 5432
+  sslmode: require
+  connect_timeout: 10
+  query_timeout_ms: 30000
+  checks: null
+
+# Supply-chain lane tunables (only used when scanners.supply_chain is true).
+supply_chain:
+  vendor: socket
+  binary: socket
+  api_key_env: SOCKET_API_KEY
+  timeout: 600
+  issue_types: []        # [] = accept all Socket issue types


### PR DESCRIPTION
Replicates the **security analysis** from ezel/gallery for lever: a nightly
CircleCI job runs the `leverj/security-scan` Docker image against the checkout
and files deduplicated findings into **GitHub Project #8**
([`leverj/lever-security-issues`](https://github.com/orgs/leverj/projects/8)).

## What's in the repo (this PR)
- `.security-scan/config.yaml` — deterministic lanes (osv, gitleaks, semgrep,
  trivy, trufflehog, syft). Supabase lane off (lever isn't Supabase-backed).
- `.security-scan/config-llm.yaml` — LLM SAST lanes (codex + claude), same board.
- `.circleci/config.yml` — `run-security-scan` pipeline param + a `security-scan`
  workflow (mac-mini runner `leverj/macos`, `ezel-security-scan` context). The
  `setup`/test workflow is gated to skip on scan runs. `circleci config validate` passes.
- `.dev/ci-security-scan.md` — runbook for the one-time external steps.

Mirrors gallery, retargeted to `leverj/lever` @ `main` and board #8.

## ⚠️ One-time external steps (after merge — see the runbook)
1. **Nightly schedule** — create a CircleCI scheduled pipeline that sets
   `run-security-scan: true` on `main` at 02:00 UTC. (I can do this via API once merged.)
2. **PAT scope** — the shared `ezel-security-scan` context's `SECURITY_SCAN_TOKEN`
   must cover `leverj/lever` + Project #8. If it's a classic org-wide `repo`+`project`
   PAT (as ezel/gallery use), it already does — just verify.
3. **Runner online** — the `leverj/macos` mac-mini must be up when the scan fires.
4. **Slack (optional)** — `SLACK_WEBHOOK_URL` on the shared context enables run summaries.

Note: the scan files **real** GitHub issues (not a dry-run) — that's the intended
nightly behavior. First run may file a backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)