### PR TITLE
chore: enable leverj-ai skills bundle for the repo (all users)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "leverj@leverj-ai-skills": true
+  },
+  "extraKnownMarketplaces": {
+    "leverj-ai-skills": {
+      "source": {
+        "source": "github",
+        "repo": "leverj/ai-skills"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Makes the **leverj-ai skills** available to everyone working in this repo, the
same way ezel does it — by committing `.claude/settings.json`.

Enables the single `leverj@leverj-ai-skills` plugin, which bundles all four skills:
- **sprint** — scrum/kanban workflow on GitHub Projects v2
- **triage** — end-to-end triage & fix loop
- **security-scan** — drives the deterministic `leverj/security-scan` Docker image
- **security-scan-llm** — Codex+Claude+Gemma SAST

and registers its marketplace (`leverj/ai-skills`) via `extraKnownMarketplaces`, so
Claude Code auto-offers to install it on first trust of the repo. Copied from
ezel's `.claude/settings.json` minus ezel's repo-specific graphify hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)