### PR TITLE
ci(security-scan): self-heal a wedged Colima runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,29 @@ jobs:
           name: Ensure container runtime (Colima) is up
           command: |
             eval "$(/opt/homebrew/bin/brew shellenv)"
-            colima status >/dev/null 2>&1 || colima start --cpu 4 --memory 8 --disk 60
+            # Self-heal a wedged Colima VM. A plain `colima start` bails when the
+            # instance is half-dead ("vz driver is running but host agent is not"),
+            # which silently failed all three nightly scans on 2026-07-24. So: if
+            # Colima isn't healthy, try to start; on failure force-stop (SIGKILLs the
+            # vz driver and clears stale pid/socks, preserving the image cache) and
+            # retry; last resort delete + recreate. Then hard-gate on a live Docker.
+            start()   { colima start --cpu 4 --memory 8 --disk 60; }
+            healthy() { colima status >/dev/null 2>&1 && docker info >/dev/null 2>&1; }
+            if healthy; then
+              echo "Colima already up."
+            else
+              start || {
+                echo "colima start failed — force-stopping wedged instance and retrying."
+                colima stop -f 2>/dev/null || true
+                start || {
+                  echo "retry failed — deleting and recreating the Colima instance."
+                  colima delete -f 2>/dev/null || true
+                  start
+                }
+              }
+            fi
+            docker info >/dev/null 2>&1 || { echo "ERROR: Docker unavailable after Colima recovery"; exit 1; }
+            echo "Docker ready: $(docker version --format '{{.Server.Version}}')"
       - run:
           name: Run leverj/security-scan → Project #8
           no_output_timeout: 30m


### PR DESCRIPTION
## What

Make the nightly `security-scan` job's **"Ensure container runtime (Colima) is up"** step self-heal a wedged Colima VM instead of failing.

## Why

On **2026-07-24** all three nightly security scans (gallery, lever, ezel) failed identically at this step on the shared `leverj/macos` runner (mini-m4):

```
> errors inspecting instance: [vz driver is running but host agent is not]
FATA error starting vm: error at 'starting': exit status 1
```

Colima was half-crashed — the Apple Virtualization (`vz`) VM process was alive but Colima's Lima host-agent had died. The old step did `colima status … || colima start`, but `colima start` on a wedged instance also fails, so the step gave up and the scan never ran. Manually running `colima stop -f && colima start` on the runner cleared it and all three re-ran green.

## Change

If Colima isn't healthy: try `colima start`; on failure `colima stop -f` (force-kills the stray vz driver, clears stale pid/socks, **preserves the image cache**) and retry; `colima delete -f` + recreate as a last resort. Then hard-gate on `docker info` so a dead runtime fails loudly rather than scanning nothing.

CI-only change. YAML + `bash -n` validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrxocZgnwcemzKB4SHoeZo