### PR TITLE
fix(chain-deployment): harden hardhat compile against shell injection (#210)

### DIFF
--- a/packages/chain-deployment/src/Deploy.js
+++ b/packages/chain-deployment/src/Deploy.js
@@ -2,7 +2,7 @@ import {JsonFileStore} from '@leverj/lever.storage'
 import {Map} from 'immutable'
 import {default as hardhat} from 'hardhat'
 import {cloneDeep} from 'lodash-es'
-import {execSync} from 'node:child_process'
+import {execFileSync} from 'node:child_process'
 import {setTimeout} from 'node:timers/promises'
 import {inspect} from 'node:util'
 import * as networksByChain from 'viem/chains'
@@ -71,7 +71,7 @@ export class Deploy {
 
   compileContracts() {
     this.logger.log(`compiling contracts `.padEnd(120, '.'))
-    execSync(`npx hardhat compile --quiet --config ${process.cwd()}/hardhat.config.cjs`)
+    execFileSync('npx', ['hardhat', 'compile', '--quiet', '--config', `${process.cwd()}/hardhat.config.cjs`])
   }
 
   async deployContracts(chain, options) {


### PR DESCRIPTION
## Summary
Hardens `chain-deployment`'s contract-compile step against the semgrep `child-process-shell` finding (#210). Replaces `execSync` — which spawned a shell and interpolated `process.cwd()` into the command string — with `execFileSync('npx', [...])`, passing arguments as a literal array with **no shell**, eliminating the command-injection surface.

## Closes
- Closes #210

## Test plan
- [x] `@leverj/lever.chain-deployment` suite green (4 passing, 2 pending) — compile + deploy path exercised
- [x] Secrets scan clean
- [x] security-review: no findings (change strictly reduces attack surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7ANs99KxujL51u76tm21y