### PR TITLE
test(chain-tracking): stop event assertions racing the poller

### DIFF
--- a/packages/chain-tracking/.mocharc.cjs
+++ b/packages/chain-tracking/.mocharc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   file: 'test/setup.js',
+  timeout: -1,
   'node-option': ['no-warnings=ExperimentalWarning'],
 }

--- a/packages/chain-tracking/test/ContractTracker.JsonFileStore.spec.js
+++ b/packages/chain-tracking/test/ContractTracker.JsonFileStore.spec.js
@@ -27,18 +27,18 @@ describe('ContractTracker - with JsonFileStore', () => {
 
   it('can track events when polling', async () => {
     const address = contract.target
-    expectEventsToMatch(events, [])
+    await expectEventsToMatch(events, [])
 
     await contract.mint(account.address, 1000n) // => Transfer(from, to, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
     ])
 
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await contract.approve(contract.target, 5000n) // => Approval(owner, spender, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
@@ -52,7 +52,7 @@ describe('ContractTracker - with JsonFileStore', () => {
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await tracker.start()
     await setTimeout(10)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
@@ -65,7 +65,7 @@ describe('ContractTracker - with JsonFileStore', () => {
     await contract.mint(account.address, 1000n) // => Transfer(from, to, value)
     await contract.approve(contract.target, 5000n) // => Approval(owner, spender, value)
     await setTimeout(100)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
     ])
@@ -77,7 +77,7 @@ describe('ContractTracker - with JsonFileStore', () => {
     tracker = ContractTracker.of(config, chainId, contract, 0, store, _ => events.push(_))
     await tracker.start()
     await setTimeout(10)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 1500n]},

--- a/packages/chain-tracking/test/ContractTracker.SQLiteStore.spec.js
+++ b/packages/chain-tracking/test/ContractTracker.SQLiteStore.spec.js
@@ -31,18 +31,18 @@ describe('ContractTracker - with SQLiteStore', () => {
 
   it('can track events when polling', async () => {
     const address = contract.target
-    expectEventsToMatch(events, [])
+    await expectEventsToMatch(events, [])
 
     await contract.mint(account.address, 1000n) // => Transfer(from, to, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
     ])
 
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await contract.approve(contract.target, 5000n) // => Approval(owner, spender, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
@@ -56,7 +56,7 @@ describe('ContractTracker - with SQLiteStore', () => {
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await tracker.start()
     await setTimeout(50)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
@@ -69,7 +69,7 @@ describe('ContractTracker - with SQLiteStore', () => {
     await contract.mint(account.address, 1000n) // => Transfer(from, to, value)
     await contract.approve(contract.target, 5000n) // => Approval(owner, spender, value)
     await setTimeout(50)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
     ])
@@ -81,7 +81,7 @@ describe('ContractTracker - with SQLiteStore', () => {
     tracker = ContractTracker.of(config, chainId, contract, 0, store, _ => events.push(_))
     await tracker.start()
     await setTimeout(50)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 1500n]},

--- a/packages/chain-tracking/test/ContractTracker.selective-tracking.spec.js
+++ b/packages/chain-tracking/test/ContractTracker.selective-tracking.spec.js
@@ -32,14 +32,14 @@ describe('ContractTracker - selective tracking', () => {
     await tracker.poll()
     expect(await contract.balances(account, token.target)).toEqual(0n)
     // expectEventsToMatch(events, [])
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address: token.target, name: 'Transfer', args: [ETH, account.address, 1000n]},
     ])
 
     await contract.connect(account).deposit(token.target, 1000n).then(_ => _.wait()) // => Transfer(from, to, value)
     expect(await contract.balances(account, token.target)).toEqual(1000n)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address: token.target, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address: token.target, name: 'Transfer', args: [account.address, contract.target, 1000n]},
     ])
@@ -47,7 +47,7 @@ describe('ContractTracker - selective tracking', () => {
     await contract.connect(account).withdraw(token.target, 1000n / 10n).then(_ => _.wait())
     expect(await contract.balances(account, token.target)).toEqual(1000n / 10n * 9n)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address: token.target, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address: token.target, name: 'Transfer', args: [account.address, contract.target, 1000n]},
       {address: token.target, name: 'Transfer', args: [contract.target, account.address, 100n]},
@@ -62,7 +62,7 @@ describe('ContractTracker - selective tracking', () => {
     await contract.connect(account).withdraw(token.target, 1000n / 10n).then(_ => _.wait())
     await tracker.start()
     await setTimeout(10)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address: token.target, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address: token.target, name: 'Transfer', args: [account.address, contract.target, 1000n]},
       {address: token.target, name: 'Transfer', args: [contract.target, account.address, 100n]},

--- a/packages/chain-tracking/test/ContractTracker.spec.js
+++ b/packages/chain-tracking/test/ContractTracker.spec.js
@@ -24,18 +24,18 @@ describe('ContractTracker - with InMemoryCompoundKeyStore', () => {
 
   it('can track events when polling', async () => {
     const address = contract.target
-    expectEventsToMatch(events, [])
+    await expectEventsToMatch(events, [])
 
     await contract.mint(account.address, 1000n) // => Transfer(from, to, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
     ])
 
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await contract.approve(contract.target, 5000n) // => Approval(owner, spender, value)
     await tracker.poll()
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
@@ -49,7 +49,7 @@ describe('ContractTracker - with InMemoryCompoundKeyStore', () => {
     await contract.mint(account.address, 2000n) // => Transfer(from, to, value)
     await tracker.start()
     await setTimeout(10)
-    expectEventsToMatch(events, [
+    await expectEventsToMatch(events, [
       {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
       {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
       {address, name: 'Transfer', args: [ETH, account.address, 2000n]},

--- a/packages/chain-tracking/test/MultiContractTracker.spec.js
+++ b/packages/chain-tracking/test/MultiContractTracker.spec.js
@@ -28,7 +28,7 @@ describe('MultiContractTracker', () => {
       await contract.approve(contract.target, 5000n)
       await contract.mint(account.address, 2000n)
       await setTimeout(10)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address, name: 'Transfer', args: [ETH, account.address, 1000n]},
         {address, name: 'Approval', args: [deployer.address, contract.target, 5000n]},
         {address, name: 'Transfer', args: [ETH, account.address, 2000n]},
@@ -52,7 +52,7 @@ describe('MultiContractTracker', () => {
       await tracker.addContract(contract1, 'ERC20') // => will onboard
       await tracker.addContract(contract2, 'ERC20') // => will onboard
       await setTimeout(10)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address: address1, name: 'Transfer', args: [ETH, account.address, 100n]},
         {address: address1, name: 'Approval', args: [deployer.address, contract1.target, 10000n]},
         {address: address1, name: 'Transfer', args: [ETH, account.address, 2000n]},
@@ -75,18 +75,18 @@ describe('MultiContractTracker', () => {
 
       await tracker.addContract(contract1, 'ERC20')
       await setTimeout(10)
-      expectEventsToMatch(events, [])
+      await expectEventsToMatch(events, [])
 
       await tracker.start()
       await setTimeout(10)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address: address1, name: 'Transfer', args: [ETH, account.address, 100n]},
         {address: address1, name: 'Approval', args: [deployer.address, contract1.target, 10000n]},
       ])
 
       await tracker.addContract(contract2, 'ERC20')
       await setTimeout(10)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address: address1, name: 'Transfer', args: [ETH, account.address, 100n]},
         {address: address1, name: 'Approval', args: [deployer.address, contract1.target, 10000n]},
         {address: address2, name: 'Transfer', args: [ETH, account.address, 200n]},
@@ -96,7 +96,7 @@ describe('MultiContractTracker', () => {
       await contract2.approve(contract2.target, 20000n)
       await contract3.mint(account.address, 3n)
       await setTimeout(10)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address: address1, name: 'Transfer', args: [ETH, account.address, 100n]},
         {address: address1, name: 'Approval', args: [deployer.address, contract1.target, 10000n]},
         {address: address2, name: 'Transfer', args: [ETH, account.address, 200n]},
@@ -109,7 +109,7 @@ describe('MultiContractTracker', () => {
       await contract3.connect(account).approve(contract1.target, 3n)
       await contract3.mint(account.address, 6n)
       await setTimeout(20)
-      expectEventsToMatch(events, [
+      await expectEventsToMatch(events, [
         {address: address1, name: 'Transfer', args: [ETH, account.address, 100n]},
         {address: address1, name: 'Approval', args: [deployer.address, contract1.target, 10000n]},
         {address: address2, name: 'Transfer', args: [ETH, account.address, 200n]},

--- a/packages/chain-tracking/test/help.js
+++ b/packages/chain-tracking/test/help.js
@@ -1,11 +1,18 @@
 import {deployContract} from '@leverj/lever.chain-deployment/hardhat.help'
 import {expect} from 'expect'
+import {setTimeout} from 'node:timers/promises'
 
 export const ERC20 = async (name = 'Crap', symbol = 'CRAP') => deployContract('ERC20Mock', [name, symbol])
 export const ERC721 = async (name = 'Crap', symbol = 'CRAP') => deployContract('ERC721Mock', [name, symbol])
 export const Bank = async (chainId, name) => deployContract('Bank', [chainId, name])
 
-export function expectEventsToMatch(events, expected) {
+// events surface on the tracker's polling cycle, so a fixed sleep races the poller; wait for them to land instead
+const waitForEventCount = async (events, count, timeout = 2000, interval = 5) => {
+  for (let waited = 0; events.length < count && waited < timeout; waited += interval) await setTimeout(interval)
+}
+
+export async function expectEventsToMatch(events, expected) {
+  await waitForEventCount(events, expected.length)
   expect(events.length).toEqual(expected.length)
   for (let [i, {address, name, args}] of events.entries()) {
     // console.log('>'.repeat(50), i, args)


### PR DESCRIPTION
## Problem
`chain-tracking` fails **~7 of 8 runs on `main`** — it randomly reddens any PR that runs this package (including every `run-all` trigger, e.g. dependency bumps). Two independent causes:

1. **Assertions raced the poller.** Tests did `await setTimeout(10)` — a *single* polling interval (`polling: {interval: 10}`) — then asserted that all events had arrived. Any scheduling jitter dropped the last event → `Expected: 3, Received: 2`.
2. **Mocha's default 2000ms timeout.** `any.Tracker.Store.spec.js` → "maintain state for MultiContractTracker" does 12 on-chain round-trips and legitimately takes ~1.9s, sitting right on the limit.

## Fix
1. `expectEventsToMatch` now waits for the expected events to land (5ms poll, 2s cap) instead of assuming one tick delivered them; all 27 call sites `await` it. Existing sleeps are kept so negative assertions (`expectEventsToMatch(events, [])`) still get settle time.
2. `timeout: -1` in `.mocharc.cjs`, matching the convention already used by sibling package `chain-deployment` for the same kind of on-chain work.

Test-only change — no `src/` files touched.

## Result
| | failure rate |
|---|---|
| `main` | **7 / 8 runs** |
| this branch | **1 / 10 runs** |

## Known remaining cause — tracked separately
The residual ~10% is **not** a test race: it's a genuine duplicate-event bug in `MultiContractTracker` (the same log delivered twice by catch-up *and* the live poller). Filed separately; deliberately not papered over here.

## Test plan
- [x] 10 consecutive local runs (9 clean, 1 = the tracked duplicate-event bug)
- [x] Verified the pre-existing 7/8 failure rate on untouched `main` for baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7ANs99KxujL51u76tm21y