### PR TITLE
fix(deps): force adm-zip 0.4.16 -> 0.6.0 (clears CVE-2026-39244)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "resolutions": {
     "handlebars": "4.7.9",
     "elliptic": "6.6.1",
+    "adm-zip@npm:^0.4.16": "0.6.0",
     "lodash": "4.18.1",
     "validator": "13.15.35",
     "fast-uri": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,10 +2292,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"adm-zip@npm:^0.4.16":
-  version: 0.4.16
-  resolution: "adm-zip@npm:0.4.16"
-  checksum: 10c0/c56c6e138fd19006155fc716acae14d54e07c267ae19d78c8a8cdca04762bf20170a71a41aa8d8bad2f13b70d4f3e9a191009bafa5280e05a440ee506f871a55
+"adm-zip@npm:0.6.0":
+  version: 0.6.0
+  resolution: "adm-zip@npm:0.6.0"
+  checksum: 10c0/440f37590c62255226f1db4cb1a5a618879347f5106ad5b9a24c67c20f9a54bd5b4efcd2b35af858e39c7885d05f4bd35f4c2f42378c98d13f779be380bc9ae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Clears **CVE-2026-39244** (high, GHSA-xcpc-8h2w-3j85) by forcing `adm-zip` to 0.6.0 — the only version the advisory is patched in. Root `resolutions` only.

`adm-zip` is not a direct dependency: it is pulled solely by `hardhat@2.26.3` (`adm-zip: ^0.4.16`), a runtime dependency of `chain-deployment`.

## Why this was held back from the main batch
0.4.16 → 0.6.0 crosses two 0ver-major boundaries (0.4 → 0.5 → 0.6), so it was classified `needs-you` rather than trivial. Validated before shipping.

## Blast radius is one call site
`hardhat` uses adm-zip in exactly one place — `internal/solidity/compiler/downloader.js`, extracting a **Windows** solc build:

```js
const AdmZip = require("adm-zip");
const zip = new AdmZip(downloadPath);
zip.extractAllTo(solcFolder);
```

It is guarded by `this._platform === CompilerPlatform.WINDOWS`, so it never executes on Linux/macOS CI.

Because our tests use a cached compiler, a green suite alone does **not** exercise this path — so the API was tested directly against 0.6.0:

```
adm-zip version: 0.6.0
constructor ok; typeof extractAllTo = function
extractAllTo ok; extracted = [ 'solc.exe' ]
content = solc-fake-binary
```

Both APIs hardhat calls behave identically on 0.6.0.

## Closes
- Closes #316

## Test plan
- [x] `chain-deployment` green (4 passing — hardhat compile + deploy)
- [x] `chain-tracking` green (16 passing)
- [x] `yarn dependency:check` clean ×7
- [x] adm-zip 0.6.0 functionally verified against hardhat's exact call signature
- [x] Secrets scan clean

> Depends on the `chain-tracking` flake fixes (#378, #380) for reliably green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7ANs99KxujL51u76tm21y